### PR TITLE
Add Automatic-Module-Name MANIFEST.MF entries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ allprojects {
   version = "0.9.0-SNAPSHOT"
   group = "io.reactiverse"
 
-  extra["vertxVersion"] = "4.1.0"
+  extra["vertxVersion"] = "4.1.5"
   extra["elasticClientVersion"] = "7.10.1"
   extra["mutinyBindingsVersion"] = "2.7.0"
 
@@ -95,12 +95,12 @@ tasks {
 
   create<Jar>("sourcesJar") {
     from(sourceSets.main.get().allJava)
-    classifier = "sources"
+    archiveClassifier.set("sources")
   }
 
   create<Jar>("javadocJar") {
     from(javadoc)
-    classifier = "javadoc"
+    archiveClassifier.set("javadoc")
   }
 
   javadoc {
@@ -173,6 +173,6 @@ signing {
 }
 
 tasks.wrapper {
-  gradleVersion = "7.1"
+  gradleVersion = "7.2"
   distributionType = Wrapper.DistributionType.ALL
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,12 @@ tasks {
     delete.add("src/main/generated")
   }
 
+  getByName<Jar>("jar") {
+    manifest {
+      attributes(Pair("Automatic-Module-Name", "io.reactiverse.elasticsearch.client"))
+    }
+  }
+
   create<Jar>("sourcesJar") {
     from(sourceSets.main.get().allJava)
     archiveClassifier.set("sources")

--- a/elasticsearch-client-mutiny/build.gradle.kts
+++ b/elasticsearch-client-mutiny/build.gradle.kts
@@ -41,7 +41,7 @@ sourceSets {
 
 tasks {
   getByName<JavaCompile>("compileJava") {
-    options.annotationProcessorGeneratedSourcesDirectory = File("$projectDir/src/main/generated")
+    options.generatedSourceOutputDirectory.set(File("$projectDir/src/main/generated"))
   }
 
   getByName<Delete>("clean") {
@@ -54,12 +54,12 @@ tasks {
 
   create<Jar>("sourcesJar") {
     from(sourceSets.main.get().allJava)
-    classifier = "sources"
+    archiveClassifier.set("sources")
   }
 
   create<Jar>("javadocJar") {
     from(javadoc)
-    classifier = "javadoc"
+    archiveClassifier.set("javadoc")
   }
 
   javadoc {

--- a/elasticsearch-client-mutiny/build.gradle.kts
+++ b/elasticsearch-client-mutiny/build.gradle.kts
@@ -50,6 +50,9 @@ tasks {
 
   getByName<Jar>("jar") {
     exclude("io/vertx/elasticsearch/client/*.class")
+    manifest {
+      attributes(Pair("Automatic-Module-Name", "io.reactiverse.elasticsearch.client.mutiny"))
+    }
   }
 
   create<Jar>("sourcesJar") {

--- a/elasticsearch-client-rxjava2/build.gradle.kts
+++ b/elasticsearch-client-rxjava2/build.gradle.kts
@@ -41,7 +41,7 @@ sourceSets {
 
 tasks {
   getByName<JavaCompile>("compileJava") {
-    options.annotationProcessorGeneratedSourcesDirectory = File("$projectDir/src/main/generated")
+    options.generatedSourceOutputDirectory.set(File("$projectDir/src/main/generated"))
   }
 
   getByName<Delete>("clean") {
@@ -54,12 +54,12 @@ tasks {
 
   create<Jar>("sourcesJar") {
     from(sourceSets.main.get().allJava)
-    classifier = "sources"
+    archiveClassifier.set("sources")
   }
 
   create<Jar>("javadocJar") {
     from(javadoc)
-    classifier = "javadoc"
+    archiveClassifier.set("javadoc")
   }
 
   javadoc {

--- a/elasticsearch-client-rxjava2/build.gradle.kts
+++ b/elasticsearch-client-rxjava2/build.gradle.kts
@@ -50,6 +50,9 @@ tasks {
 
   getByName<Jar>("jar") {
     exclude("io/vertx/elasticsearch/client/*.class")
+    manifest {
+      attributes(Pair("Automatic-Module-Name", "io.reactiverse.elasticsearch.client.rxjava2"))
+    }
   }
 
   create<Jar>("sourcesJar") {

--- a/elasticsearch-client-rxjava3/build.gradle.kts
+++ b/elasticsearch-client-rxjava3/build.gradle.kts
@@ -41,7 +41,7 @@ sourceSets {
 
 tasks {
   getByName<JavaCompile>("compileJava") {
-    options.annotationProcessorGeneratedSourcesDirectory = File("$projectDir/src/main/generated")
+    options.generatedSourceOutputDirectory.set(File("$projectDir/src/main/generated"))
   }
 
   getByName<Delete>("clean") {
@@ -54,12 +54,12 @@ tasks {
 
   create<Jar>("sourcesJar") {
     from(sourceSets.main.get().allJava)
-    classifier = "sources"
+    archiveClassifier.set("sources")
   }
 
   create<Jar>("javadocJar") {
     from(javadoc)
-    classifier = "javadoc"
+    archiveClassifier.set("javadoc")
   }
 
   javadoc {

--- a/elasticsearch-client-rxjava3/build.gradle.kts
+++ b/elasticsearch-client-rxjava3/build.gradle.kts
@@ -50,6 +50,9 @@ tasks {
 
   getByName<Jar>("jar") {
     exclude("io/vertx/elasticsearch/client/*.class")
+    manifest {
+      attributes(Pair("Automatic-Module-Name", "io.reactiverse.elasticsearch.client.rxjava3"))
+    }
   }
 
   create<Jar>("sourcesJar") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionSha256Sum=a8da5b02437a60819cad23e10fc7e9cf32bcb57029d9cb277e26eeff76ce014b
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/shim-generator/build.gradle.kts
+++ b/shim-generator/build.gradle.kts
@@ -38,7 +38,7 @@ tasks {
   }
 
   create<JavaExec>("elastic-process") {
-    main = "shimgen.Analyze"
+    mainClass.set("shimgen.Analyze")
     classpath = sourceSets["main"].runtimeClasspath
     args = listOf(
       "$elasticSourcesDir/org/elasticsearch/client/RestHighLevelClient.java",


### PR DESCRIPTION
This adds the `Automatic-Module-Name` entries to the `MANIFEST.MF` files in the four `jar` artifacts that we publish. Module names are:

  - `io.reactiverse.elasticsearch.client`
  - `io.reactiverse.elasticsearch.client.mutiny`
  - `io.reactiverse.elasticsearch.client.rxjava2`
  - `io.reactiverse.elasticsearch.client.rxjava3`